### PR TITLE
Update splash.storyboard

### DIFF
--- a/templates/ios/storyboards/splash.storyboard
+++ b/templates/ios/storyboards/splash.storyboard
@@ -4,7 +4,7 @@
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <deployment version="2304" identifier="iOS"/>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>


### PR DESCRIPTION
Fixes Xcode warning "Unsupported Configuration: This file is set to build for a version older than the deployment target. Functionality may be limited." Splash storyboard automatically set to Stencyl Target Deployment